### PR TITLE
Use Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,25 +11,12 @@ cd text-nlu
 docker build -t text-nlu:latest .
 ``` 
 
-## Start a container network
+## Start using Docker Compose
+Use docker-compose to start the TFserving and the text-nlu:
 ```
-docker network create text-nlu-net
+docker-compose up
 ```
-
-## Launch the TFserving
-```
-docker run -t --rm -p 8500:8500 -v "$(pwd)/models/:/models/" --name tensorflow_serving --network text-nlu-net tensorflow/serving:latest  --model_config_file=/models/models_config.yaml
-```
-
-## Launch the API
-```
-docker run -p 9009:9009 --name text_nlu --network text-nlu-net text-nlu:latest --model-config <filename> [--port <port>] [--threads <nthreads>] [--debug]
-
---model-config (-c)      config file in which all models are described (REQUIRED)
---threads (-t)           number of threads (default 1)
---debug (-d)             debug mode (default false)
---help (-h)              show this message
-```
+You can change params in the docker-compose.yml.
 
 ## Licencing
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 port: 9009
 threads: 2
 debug: 1
-model_config_path: /opt/text-nlu/models/models_config.yaml
+model_config_path: /models/models_config.yaml
+#TODO: use ENV variables in docker-compose instead

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3"
+services:
+  nlu:
+    image: text-nlu:latest
+    ports:
+      - "9009:9009"
+    volumes:
+      - ./models:/models
+    command: -c config.yaml -d -g
+    # TODO: use env variable instead later
+  tensorflow_serving:
+    image: "tensorflow/serving:latest"
+    volumes:
+      - ./models:/models
+    command: --model_config_file=/models/models_config.yaml
+    # We can't set MODEL_CONFIG_FILE environment variable:
+    # See https://github.com/tensorflow/serving/issues/1165

--- a/src/abstract_server.cpp
+++ b/src/abstract_server.cpp
@@ -6,10 +6,10 @@
 AbstractServer::AbstractServer(string &config_file, int debug_mode){
   _debug_mode = debug_mode;
 
+  ProcessConfigFile(config_file);
+
   _nlu = make_shared<nlu>(debug_mode, _model_config_path);
   // TODO: Test if NLU started correctly
-
-  ProcessConfigFile(config_file);
 }
 
 void AbstractServer::ProcessConfigFile(std::string &config_file) {

--- a/src/nlu.cpp
+++ b/src/nlu.cpp
@@ -30,13 +30,9 @@ std::vector<std::string> nlu::getDomains(){
 
   std::vector<std::string> domain_list;
 
-  // TODO: Improve way to get absolute path to the config file.
-  std::string filename = "/opt/text-nlu/models/models_config.yaml";
-
   tensorflow::serving::ModelServerConfig *server_config = new tensorflow::serving::ModelServerConfig();
 
-
-  int fileDescriptor = open(filename.c_str(), O_RDONLY);
+  int fileDescriptor = open(_model_config_path.c_str(), O_RDONLY);
   if( fileDescriptor < 0 ) {
     std::cerr << " Error opening the file " << std::endl;
     return domain_list;


### PR DESCRIPTION
Following #6 and solving #4.

Using Docker Compose to start both containers: TFserving and gRPC.

This allows us to simply run the two containers with the good configuration:
- they are in the same network and can communicate using gRPC,
- they share same volume /models/ to allow for model changes on the fly,
- we can set ENV variables in the docker-compose.