### PR TITLE
Improve exceptions handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ compile_proto(0 "${CMAKE_SOURCE_DIR}/protos" "${CMAKE_SOURCE_DIR}/compiled" PB_S
 # Compiling CPP sources with gRPC plugin.
 compile_proto(1 "${CMAKE_SOURCE_DIR}/protos" "${CMAKE_SOURCE_DIR}/compiled" PB_GRPC_SOURCES PB_GRPC_HEADERS
         protos/tensorflow_serving/apis/prediction_service.proto
-        protos/tensorflow_serving/config/model_server_config.proto
+        protos/tensorflow_serving/apis/model_service.proto
         protos/grpc_nlu.proto
 )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       API_NLU_CONFIG: /models/models.config
       API_NLU_GRPC: 0
       API_NLU_DEBUG: 1
+    depends_on:
+      - "tensorflow_serving"
 
   tensorflow_serving:
     image: "tensorflow/serving:latest"

--- a/include/grpc_route_nlu_impl.h
+++ b/include/grpc_route_nlu_impl.h
@@ -12,6 +12,8 @@
 #include "nlu.h"
 #include "utils.h"
 
+using grpc::Status;
+
 class GrpcRouteNLUImpl : public RouteNLU::Service {
 public:
     GrpcRouteNLUImpl(shared_ptr<nlu> nlu_ptr, int debug_mode);

--- a/include/nlu.h
+++ b/include/nlu.h
@@ -81,6 +81,8 @@ class nlu
           std::string domain);
         bool CheckModelsStatus();
     private:
+      static map<tensorflow::serving::ModelVersionStatus_State, std::string> mapState;
+
       unique_ptr<PredictionService::Stub> _stub;
       shared_ptr<Channel> _channel;
 
@@ -96,7 +98,6 @@ class nlu
         std::vector<std::vector<std::vector<std::string>>>& chars_list_batch,
         std::vector<std::vector<std::string>>& batch_tokens, 
         int max_length_word);
-      std::string getModelStatusStringState(tensorflow::serving::ModelVersionStatus_State state);
 };
 
 

--- a/include/nlu.h
+++ b/include/nlu.h
@@ -17,7 +17,7 @@
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 
 #include "tensorflow_serving/apis/prediction_service.grpc.pb.h"
-#include "tensorflow_serving/config/model_server_config.grpc.pb.h"
+#include "tensorflow_serving/apis/model_service.grpc.pb.h"
 
 #include "tokenizer.h"
 #include "utils.h"
@@ -32,6 +32,7 @@ using grpc::Status;
 using tensorflow::serving::PredictRequest;
 using tensorflow::serving::PredictResponse;
 using tensorflow::serving::PredictionService;
+using tensorflow::serving::ModelService;
 
 typedef google::protobuf::Map<std::string, tensorflow::TensorProto> OutMap;
 
@@ -78,8 +79,10 @@ class nlu
           std::vector<std::vector<std::string> >& batch_tokens,
           std::vector<std::vector<std::string> >& output_batch_tokens,
           std::string domain);
+        bool CheckModelsStatus();
     private:
       unique_ptr<PredictionService::Stub> _stub;
+      shared_ptr<Channel> _channel;
 
       bool _local;
       tokenizer * _tokenizer;
@@ -93,6 +96,7 @@ class nlu
         std::vector<std::vector<std::vector<std::string>>>& chars_list_batch,
         std::vector<std::vector<std::string>>& batch_tokens, 
         int max_length_word);
+      std::string getModelStatusStringState(tensorflow::serving::ModelVersionStatus_State state);
 };
 
 

--- a/include/nlu.h
+++ b/include/nlu.h
@@ -20,6 +20,7 @@
 #include "tensorflow_serving/config/model_server_config.grpc.pb.h"
 
 #include "tokenizer.h"
+#include "utils.h"
 
 
 #include <grpcpp/grpcpp.h>
@@ -73,7 +74,7 @@ class nlu
         std::vector <std::string> tokenize(std::string &input, std::string lang);
         std::string tokenize_str(std::string &input, std::string lang);
 
-        bool NLUBatch(
+        Status NLUBatch(
           std::vector<std::vector<std::string> >& batch_tokens,
           std::vector<std::vector<std::string> >& output_batch_tokens,
           std::string domain);

--- a/include/rest_server.h
+++ b/include/rest_server.h
@@ -15,12 +15,15 @@
 #include <sstream>
 #include <time.h>
 #include "yaml-cpp/yaml.h"
+#include <grpcpp/grpcpp.h>
 
 #include "abstract_server.h"
 
 using namespace std;
 using namespace nlohmann;
 using namespace Pistache;
+
+using grpc::Status;
 
 class rest_server : public AbstractServer {
 
@@ -53,8 +56,8 @@ private:
                               int& count,
                               float& threshold,
                               bool& debugmode);
-  bool askNLU(std::string &text, std::string &tokenized, json &output, string &domain, string &lang, bool debugmode);
-  bool askNLU(vector<vector<string> > &input, json &output, string &domain, string &lang, bool debugmode);
+  Status askNLU(std::string &text, std::string &tokenized, json &output, string &domain, string &lang, bool debugmode);
+  Status askNLU(vector<vector<string> > &input, json &output, string &domain, string &lang, bool debugmode);
 
   void writeLog(string text_to_log) {}
 

--- a/protos/tensorflow/core/lib/core/error_codes.proto
+++ b/protos/tensorflow/core/lib/core/error_codes.proto
@@ -1,0 +1,148 @@
+syntax = "proto3";
+
+package tensorflow.error;
+option cc_enable_arenas = true;
+option java_outer_classname = "ErrorCodesProtos";
+option java_multiple_files = true;
+option java_package = "org.tensorflow.framework";
+
+// The canonical error codes for TensorFlow APIs.
+//
+// Warnings:
+//
+// -   Do not change any numeric assignments.
+// -   Changes to this list should only be made if there is a compelling
+//     need that can't be satisfied in another way.  Such changes
+//     must be approved by at least two OWNERS.
+//
+// Sometimes multiple error codes may apply.  Services should return
+// the most specific error code that applies.  For example, prefer
+// OUT_OF_RANGE over FAILED_PRECONDITION if both codes apply.
+// Similarly prefer NOT_FOUND or ALREADY_EXISTS over FAILED_PRECONDITION.
+enum Code {
+  // Not an error; returned on success
+  OK = 0;
+
+  // The operation was cancelled (typically by the caller).
+  CANCELLED = 1;
+
+  // Unknown error.  An example of where this error may be returned is
+  // if a Status value received from another address space belongs to
+  // an error-space that is not known in this address space.  Also
+  // errors raised by APIs that do not return enough error information
+  // may be converted to this error.
+  UNKNOWN = 2;
+
+  // Client specified an invalid argument.  Note that this differs
+  // from FAILED_PRECONDITION.  INVALID_ARGUMENT indicates arguments
+  // that are problematic regardless of the state of the system
+  // (e.g., a malformed file name).
+  INVALID_ARGUMENT = 3;
+
+  // Deadline expired before operation could complete.  For operations
+  // that change the state of the system, this error may be returned
+  // even if the operation has completed successfully.  For example, a
+  // successful response from a server could have been delayed long
+  // enough for the deadline to expire.
+  DEADLINE_EXCEEDED = 4;
+
+  // Some requested entity (e.g., file or directory) was not found.
+  // For privacy reasons, this code *may* be returned when the client
+  // does not have the access right to the entity.
+  NOT_FOUND = 5;
+
+  // Some entity that we attempted to create (e.g., file or directory)
+  // already exists.
+  ALREADY_EXISTS = 6;
+
+  // The caller does not have permission to execute the specified
+  // operation.  PERMISSION_DENIED must not be used for rejections
+  // caused by exhausting some resource (use RESOURCE_EXHAUSTED
+  // instead for those errors).  PERMISSION_DENIED must not be
+  // used if the caller can not be identified (use UNAUTHENTICATED
+  // instead for those errors).
+  PERMISSION_DENIED = 7;
+
+  // The request does not have valid authentication credentials for the
+  // operation.
+  UNAUTHENTICATED = 16;
+
+  // Some resource has been exhausted, perhaps a per-user quota, or
+  // perhaps the entire file system is out of space.
+  RESOURCE_EXHAUSTED = 8;
+
+  // Operation was rejected because the system is not in a state
+  // required for the operation's execution.  For example, directory
+  // to be deleted may be non-empty, an rmdir operation is applied to
+  // a non-directory, etc.
+  //
+  // A litmus test that may help a service implementor in deciding
+  // between FAILED_PRECONDITION, ABORTED, and UNAVAILABLE:
+  //  (a) Use UNAVAILABLE if the client can retry just the failing call.
+  //  (b) Use ABORTED if the client should retry at a higher-level
+  //      (e.g., restarting a read-modify-write sequence).
+  //  (c) Use FAILED_PRECONDITION if the client should not retry until
+  //      the system state has been explicitly fixed.  E.g., if an "rmdir"
+  //      fails because the directory is non-empty, FAILED_PRECONDITION
+  //      should be returned since the client should not retry unless
+  //      they have first fixed up the directory by deleting files from it.
+  //  (d) Use FAILED_PRECONDITION if the client performs conditional
+  //      REST Get/Update/Delete on a resource and the resource on the
+  //      server does not match the condition. E.g., conflicting
+  //      read-modify-write on the same resource.
+  FAILED_PRECONDITION = 9;
+
+  // The operation was aborted, typically due to a concurrency issue
+  // like sequencer check failures, transaction aborts, etc.
+  //
+  // See litmus test above for deciding between FAILED_PRECONDITION,
+  // ABORTED, and UNAVAILABLE.
+  ABORTED = 10;
+
+  // Operation tried to iterate past the valid input range.  E.g., seeking or
+  // reading past end of file.
+  //
+  // Unlike INVALID_ARGUMENT, this error indicates a problem that may
+  // be fixed if the system state changes. For example, a 32-bit file
+  // system will generate INVALID_ARGUMENT if asked to read at an
+  // offset that is not in the range [0,2^32-1], but it will generate
+  // OUT_OF_RANGE if asked to read from an offset past the current
+  // file size.
+  //
+  // There is a fair bit of overlap between FAILED_PRECONDITION and
+  // OUT_OF_RANGE.  We recommend using OUT_OF_RANGE (the more specific
+  // error) when it applies so that callers who are iterating through
+  // a space can easily look for an OUT_OF_RANGE error to detect when
+  // they are done.
+  OUT_OF_RANGE = 11;
+
+  // Operation is not implemented or not supported/enabled in this service.
+  UNIMPLEMENTED = 12;
+
+  // Internal errors.  Means some invariant expected by the underlying
+  // system has been broken.  If you see one of these errors,
+  // something is very broken.
+  INTERNAL = 13;
+
+  // The service is currently unavailable.  This is a most likely a
+  // transient condition and may be corrected by retrying with
+  // a backoff.
+  //
+  // See litmus test above for deciding between FAILED_PRECONDITION,
+  // ABORTED, and UNAVAILABLE.
+  UNAVAILABLE = 14;
+
+  // Unrecoverable data loss or corruption.
+  DATA_LOSS = 15;
+
+  // An extra enum entry to prevent people from writing code that
+  // fails to compile when a new code is added.
+  //
+  // Nobody should ever reference this enumeration entry. In particular,
+  // if you write C++ code that switches on this enumeration, add a default:
+  // case instead of a case that mentions this enumeration entry.
+  //
+  // Nobody should rely on the value (currently 20) listed here.  It
+  // may change in the future.
+  DO_NOT_USE_RESERVED_FOR_FUTURE_EXPANSION_USE_DEFAULT_IN_SWITCH_INSTEAD_ = 20;
+}

--- a/protos/tensorflow_serving/apis/get_model_status.proto
+++ b/protos/tensorflow_serving/apis/get_model_status.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+option cc_enable_arenas = true;
+
+import "tensorflow_serving/apis/model.proto";
+import "tensorflow_serving/util/status.proto";
+
+package tensorflow.serving;
+
+// GetModelStatusRequest contains a ModelSpec indicating the model for which
+// to get status.
+message GetModelStatusRequest {
+  // Model Specification. If version is not specified, information about all
+  // versions of the model will be returned. If a version is specified, the
+  // status of only that version will be returned.
+  ModelSpec model_spec = 1;
+}
+
+// Version number, state, and status for a single version of a model.
+message ModelVersionStatus {
+  // Model version.
+  int64 version = 1;
+
+  // States that map to ManagerState enum in
+  // tensorflow_serving/core/servable_state.h
+  enum State {
+    // Default value.
+    UNKNOWN = 0;
+
+    // The manager is tracking this servable, but has not initiated any action
+    // pertaining to it.
+    START = 10;
+
+    // The manager has decided to load this servable. In particular, checks
+    // around resource availability and other aspects have passed, and the
+    // manager is about to invoke the loader's Load() method.
+    LOADING = 20;
+
+    // The manager has successfully loaded this servable and made it available
+    // for serving (i.e. GetServableHandle(id) will succeed). To avoid races,
+    // this state is not reported until *after* the servable is made
+    // available.
+    AVAILABLE = 30;
+
+    // The manager has decided to make this servable unavailable, and unload
+    // it. To avoid races, this state is reported *before* the servable is
+    // made unavailable.
+    UNLOADING = 40;
+
+    // This servable has reached the end of its journey in the manager. Either
+    // it loaded and ultimately unloaded successfully, or it hit an error at
+    // some point in its lifecycle.
+    END = 50;
+  }
+
+  // Model state.
+  State state = 2;
+
+  // Model status.
+  StatusProto status = 3;
+}
+
+// Response for ModelStatusRequest on successful run.
+message GetModelStatusResponse {
+  // Version number and status information for applicable model version(s).
+  repeated ModelVersionStatus model_version_status = 1;
+}

--- a/protos/tensorflow_serving/apis/model_management.proto
+++ b/protos/tensorflow_serving/apis/model_management.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+import "tensorflow_serving/config/model_server_config.proto";
+import "tensorflow_serving/util/status.proto";
+
+package tensorflow.serving;
+option cc_enable_arenas = true;
+
+message ReloadConfigRequest {
+  ModelServerConfig config = 1;
+}
+
+message ReloadConfigResponse {
+  StatusProto status = 1;
+}

--- a/protos/tensorflow_serving/apis/model_service.proto
+++ b/protos/tensorflow_serving/apis/model_service.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+option cc_enable_arenas = true;
+
+import "tensorflow_serving/apis/get_model_status.proto";
+import "tensorflow_serving/apis/model_management.proto";
+
+package tensorflow.serving;
+
+// ModelService provides methods to query and update the state of the server,
+// e.g. which models/versions are being served.
+service ModelService {
+  // Gets status of model. If the ModelSpec in the request does not specify
+  // version, information about all versions of the model will be returned. If
+  // the ModelSpec in the request does specify a version, the status of only
+  // that version will be returned.
+  rpc GetModelStatus(GetModelStatusRequest) returns (GetModelStatusResponse);
+
+  // Reloads the set of served models. The new config supersedes the old one,
+  // so if a model is omitted from the new config it will be unloaded and no
+  // longer served.
+  rpc HandleReloadConfigRequest(ReloadConfigRequest)
+      returns (ReloadConfigResponse);
+}

--- a/protos/tensorflow_serving/util/status.proto
+++ b/protos/tensorflow_serving/util/status.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+option cc_enable_arenas = true;
+
+import "tensorflow/core/lib/core/error_codes.proto";
+
+package tensorflow.serving;
+
+// Status that corresponds to Status in
+// third_party/tensorflow/core/lib/core/status.h.
+message StatusProto {
+  // Error code.
+  error.Code error_code = 1;
+
+  // Error message. Will only be set if an error was encountered.
+  string error_message = 2;
+}

--- a/src/abstract_server.cpp
+++ b/src/abstract_server.cpp
@@ -10,5 +10,4 @@ AbstractServer::AbstractServer(std::string& model_config_path, std::string& tfse
   _tfserving_host = tfserving_host;
 
   _nlu = make_shared<nlu>(_debug_mode, _model_config_path, _tfserving_host);
-  // TODO: Test if NLU started correctly
 }

--- a/src/grpc_route_nlu_impl.cpp
+++ b/src/grpc_route_nlu_impl.cpp
@@ -38,7 +38,11 @@ grpc::Status GrpcRouteNLUImpl::GetNLU(grpc::ServerContext* context,
   tokenized_batched.push_back(tokenized_vec);
  
   std::vector<std::vector<std::string>> output_batch_tokens;
-  _nlu->NLUBatch(tokenized_batched, output_batch_tokens, domain);
+  Status status = _nlu->NLUBatch(tokenized_batched, output_batch_tokens, domain);
+  if (!status.ok()){
+    return status;
+  }
+  
   response->set_tokenized(tokenized_text);
 
   SetOutput(response, tokenized_batched, output_batch_tokens);
@@ -73,7 +77,11 @@ grpc::Status GrpcRouteNLUImpl::StreamNLU(grpc::ServerContext* context,
     tokenized_batched.push_back(tokenized_vec);
   
     std::vector<std::vector<std::string>> output_batch_tokens;
-    _nlu->NLUBatch(tokenized_batched, output_batch_tokens, domain);
+    Status status =_nlu->NLUBatch(tokenized_batched, output_batch_tokens, domain);
+    if (!status.ok()){
+      return status;
+    }
+
     response.set_tokenized(tokenized_text);
 
     SetOutput(&response, tokenized_batched, output_batch_tokens);

--- a/src/grpc_server.cpp
+++ b/src/grpc_server.cpp
@@ -15,7 +15,7 @@ void grpc_server::start(){
   builder.RegisterService(_service);
 
   std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
-  std::cout << "Server listening on " << server_address << std::endl;
+  std::cout << "[INFO]\t" << currentDateTime() <<"\tgRPC server listening on " << server_address << std::endl;
   server->Wait();
 }
 

--- a/src/nlu.cpp
+++ b/src/nlu.cpp
@@ -22,8 +22,7 @@ bool nlu::getLocal()
 
 nlu::nlu(int debug_mode, std::string model_config_path, std::string tfserving_host)
 {
-    std::string channel_string(tfserving_host);
-    _channel = CreateChannel(channel_string, grpc::InsecureChannelCredentials());
+    _channel = CreateChannel(tfserving_host, grpc::InsecureChannelCredentials());
 
     _stub = PredictionService::NewStub(_channel);
     _local=true;
@@ -55,7 +54,7 @@ bool nlu::CheckModelsStatus() {
       return false;
     }
     
-    // We currently support only one version per model, that's why we have check only first model_version_status
+    // We currently support only one version per model, that's why we check only first model_version_status
     if (_debug_mode){
       tensorflow::serving::ModelVersionStatus_State state = response.model_version_status().at(0).state();
       cerr << "[DEBUG]\t" << currentDateTime() << "\t" << domain << " model status: " << mapState[state] << endl;

--- a/src/nlu.cpp
+++ b/src/nlu.cpp
@@ -4,6 +4,17 @@
 
 using namespace std;
 
+// Initialize ModelState const
+map<tensorflow::serving::ModelVersionStatus_State, std::string> nlu::mapState = {
+  {tensorflow::serving::ModelVersionStatus_State_UNKNOWN, "UNKNOWN"},
+  {tensorflow::serving::ModelVersionStatus_State_START, "START"},
+  {tensorflow::serving::ModelVersionStatus_State_LOADING, "LOADING"},
+  {tensorflow::serving::ModelVersionStatus_State_AVAILABLE, "AVAILABLE"},
+  {tensorflow::serving::ModelVersionStatus_State_UNLOADING, "UNLOADING"},
+  {tensorflow::serving::ModelVersionStatus_State_END, "END"}
+};
+
+
 bool nlu::getLocal()
 {
     return _local;
@@ -47,29 +58,10 @@ bool nlu::CheckModelsStatus() {
     // We currently support only one version per model, that's why we have check only first model_version_status
     if (_debug_mode){
       tensorflow::serving::ModelVersionStatus_State state = response.model_version_status().at(0).state();
-      cerr << "[DEBUG]\t" << currentDateTime() << "\t" << domain << " model status: " << getModelStatusStringState(state) << endl;
+      cerr << "[DEBUG]\t" << currentDateTime() << "\t" << domain << " model status: " << mapState[state] << endl;
     } 
   }
   return true;
-}
-
-std::string nlu::getModelStatusStringState(tensorflow::serving::ModelVersionStatus_State state) {
-  // See get_model_status.proto for more information on State ENUM
-  switch(state){
-    case tensorflow::serving::ModelVersionStatus_State_UNKNOWN:
-      return "UNKNOWN";
-    case tensorflow::serving::ModelVersionStatus_State_START:
-      return "START";
-    case tensorflow::serving::ModelVersionStatus_State_LOADING:
-      return "LOADING";
-    case tensorflow::serving::ModelVersionStatus_State_AVAILABLE:
-      return "AVAILABLE";
-    case tensorflow::serving::ModelVersionStatus_State_UNLOADING:
-      return "UNLOADING";
-    case tensorflow::serving::ModelVersionStatus_State_END:
-      return "END";
-  }
-  return "UNKNOWN";
 }
 
 std::vector<std::string> nlu::getDomains(){

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -93,7 +93,11 @@ void rest_server::doNLUPost(const Rest::Request &request,
     string tokenized;
     if (_debug_mode != 0)
       cerr << "[DEBUG]\t" << currentDateTime() << "\t" << "ASK NLU:\t" << j << endl;
-    askNLU(text, tokenized, j, domain, lang, debugmode);
+    Status status = askNLU(text, tokenized, j, domain, lang, debugmode);
+    if (!status.ok()){
+      response.headers().add<Http::Header::ContentType>(MIME(Application, Json));
+      response.send(Http::Code::Internal_Server_Error, std::string(status.error_message()));
+    }
     j.push_back(nlohmann::json::object_t::value_type(string("tokenized"), tokenized));
 
     std::string s = j.dump();
@@ -136,7 +140,11 @@ void rest_server::doNLUBatchPost(const Rest::Request &request,
         string tokenized;
         if (_debug_mode != 0)
           cerr << "[DEBUG]\t" << currentDateTime() << "\tASK NLU:\t" << it << endl;
-        askNLU(text, tokenized, it, domain, lang, debugmode);
+        Status status = askNLU(text, tokenized, it, domain, lang, debugmode);
+        if (!status.ok()){
+          response.headers().add<Http::Header::ContentType>(MIME(Application, Json));
+          response.send(Http::Code::Internal_Server_Error, std::string(status.error_message()));
+        }
         it.push_back(nlohmann::json::object_t::value_type(string("tokenized"), tokenized));
       }
       else 
@@ -191,7 +199,7 @@ void rest_server::fetchParamWithDefault(const nlohmann::json& j,
   }
 }
 
-bool rest_server::askNLU(std::string &text, std::string &tokenized_text, json &output, string &domain, string &lang, bool debugmode)
+Status rest_server::askNLU(std::string &text, std::string &tokenized_text, json &output, string &domain, string &lang, bool debugmode)
 {
     tokenized_text = _nlu->tokenize_str(text, lang);
     std::vector<std::string> tokenized_vec = _nlu->tokenize(text, lang);
@@ -215,10 +223,13 @@ bool rest_server::askNLU(std::string &text, std::string &tokenized_text, json &o
     return askNLU(tokenized_batched, output, domain, lang, debugmode);
 }
 
-bool rest_server::askNLU(vector<vector<string> > &input, json &output, string &domain, string &lang, bool debugmode)
+Status rest_server::askNLU(vector<vector<string> > &input, json &output, string &domain, string &lang, bool debugmode)
 {
     vector<vector<string> > result_batched ;
-    _nlu->NLUBatch(input,result_batched, domain);
+    Status status = _nlu->NLUBatch(input,result_batched, domain);
+    if (!status.ok()){
+      return status;
+    }
     
     json i_tmp = json::array();
     json k_tmp = json::array();
@@ -274,7 +285,7 @@ bool rest_server::askNLU(vector<vector<string> > &input, json &output, string &d
     }
     if (debugmode) output.push_back(nlohmann::json::object_t::value_type(string("NLU_DEBUG"), i_tmp));
     output.push_back(nlohmann::json::object_t::value_type(string("NLU"), k_tmp));
-    return true;
+    return status;
 }
 
 

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -20,7 +20,10 @@ void rest_server::init(size_t thr) {
 
 void rest_server::start() {
   httpEndpoint->setHandler(router.handler());
+
+  cout << "[INFO]\t" << currentDateTime() <<"\tREST server listening on 0.0.0.0:" << _num_port << endl;
   httpEndpoint->serve();
+
   httpEndpoint->shutdown();
 }
 


### PR DESCRIPTION
Solving #5.

Returning the appropriate Status.
If the call to gRPC TFserving fails or the model is missing errors are propagated and finally sent to the client.
We also check model status on NLU startup and print their state on debug.